### PR TITLE
Force all plays to use sudo

### DIFF
--- a/trusted-analytics-platform.yaml
+++ b/trusted-analytics-platform.yaml
@@ -189,7 +189,7 @@ resources:
                   unzip one-click-deployment-master.zip
 
                   cd one-click-deployment-master/ansible/
-                  ansible-playbook --limit $HOSTNAME ${HOSTNAME}.yml
+                  ansible-playbook --limit $HOSTNAME --sudo ${HOSTNAME}.yml
 
                   wc_notify --data-binary '{"status": "SUCCESS"}'
             runcmd:
@@ -284,7 +284,7 @@ resources:
                   unzip one-click-deployment-master.zip
 
                   cd one-click-deployment-master/ansible/
-                  ansible-playbook --extra-vars "cf_admin_password=%password%" --limit $HOSTNAME ${HOSTNAME}.yml
+                  ansible-playbook --extra-vars "cf_admin_password=%password%" --limit $HOSTNAME --sudo ${HOSTNAME}.yml
 
                   wc_notify --data-binary '{"status": "SUCCESS"}'
             runcmd:


### PR DESCRIPTION
Needed for BOSH CLI. `cloud-init` doesn't set environment variables.
