### PR TITLE
Remove dependency on Hadoop server

### DIFF
--- a/trusted-analytics-platform.yaml
+++ b/trusted-analytics-platform.yaml
@@ -237,7 +237,6 @@ resources:
 
   cloudfoundry_server:
     type: "OS::Nova::Server"
-    depends_on: cloudera_wait_condition
     properties:
       key_name: { get_resource: ssh_key }
       flavor: { get_param: cloudfoundry_flavor }


### PR DESCRIPTION
We can now provision both servers in parallel.
