### PR TITLE
Increase volume size for Applications and change timeout for creating servers

### DIFF
--- a/trusted-analytics-platform.yaml
+++ b/trusted-analytics-platform.yaml
@@ -141,7 +141,7 @@ resources:
     type: OS::Heat::SwiftSignal
     properties:
       handle: { get_resource: cloudera_wait_condition_handle }
-      timeout: 3600
+      timeout: 7200
 
   cloudera_wait_condition_handle:
     type: OS::Heat::SwiftSignalHandle
@@ -240,7 +240,7 @@ resources:
     type: OS::Heat::SwiftSignal
     properties:
       handle: { get_resource: cloudfoundry_wait_condition_handle }
-      timeout: 14400
+      timeout: 7200
 
   cloudfoundry_wait_condition_handle:
     type: OS::Heat::SwiftSignalHandle

--- a/trusted-analytics-platform.yaml
+++ b/trusted-analytics-platform.yaml
@@ -118,10 +118,10 @@ parameters:
   cloudfoundry_size:
     label: Volume Size
     type: number
-    default: 120
+    default: 150
     description: Disk size for the Applications server
     constraints:
-      - range: { min: 120, max: 3072 }
+      - range: { min: 150, max: 3072 }
 
 resources:
 


### PR DESCRIPTION
Changed minimum size of disk for the Applications server and timeout for creating Hadoop and Applications servers.

The larger volume is needed because some Docker images used by TAP increased their size. 
